### PR TITLE
Fix daysToCover field name

### DIFF
--- a/SECFilingsDownloader/FINRAClient.swift
+++ b/SECFilingsDownloader/FINRAClient.swift
@@ -142,7 +142,7 @@ class FINRAClient {
                     shortInterest: shortVolume,
                     shortInterestRatio: shortPercent / 100,
                     percentOfFloat: 0, // Would need additional data
-                    daysTocover: 0, // Would need average volume
+                    daysToCover: 0, // Would need average volume
                     previousShortInterest: 0, // Would need historical data
                     changePercent: 0,
                     recordDate: recordDate,

--- a/SECFilingsDownloader/IntelligencePackageModels.swift
+++ b/SECFilingsDownloader/IntelligencePackageModels.swift
@@ -48,11 +48,23 @@ struct ShortInterestData: Codable {
     let shortInterest: Int
     let shortInterestRatio: Double
     let percentOfFloat: Double
-    let daysTocover: Double
+    let daysToCover: Double
     let previousShortInterest: Int
     let changePercent: Double
     let recordDate: Date
     let settlementDate: Date
+
+    enum CodingKeys: String, CodingKey {
+        case symbol
+        case shortInterest
+        case shortInterestRatio
+        case percentOfFloat
+        case daysToCover = "daysTocover"
+        case previousShortInterest
+        case changePercent
+        case recordDate
+        case settlementDate
+    }
 }
 
 struct DataSources: Codable {


### PR DESCRIPTION
## Summary
- rename `daysTocover` to `daysToCover`
- update FINRA parsing to use the new property name
- add coding key to preserve previous JSON key

## Testing
- `swiftc -parse SECFilingsDownloader/IntelligencePackageModels.swift`
- `swiftc -parse SECFilingsDownloader/FINRAClient.swift`


------
https://chatgpt.com/codex/tasks/task_e_68724edb5be08332b683349dbb438d7b