### PR TITLE
Add download-all filings option and remove selection limit

### DIFF
--- a/SECFilingsDownloader/ContentView.swift
+++ b/SECFilingsDownloader/ContentView.swift
@@ -124,7 +124,7 @@ struct FilingsDownloaderView: View {
                             .imageScale(.large)
                     }
                     .buttonStyle(.plain)
-                    .disabled(viewModel.selectedFilingTypes.count >= 4 || viewModel.isDownloading)
+                    .disabled(viewModel.isDownloading)
                 }
             }
         }
@@ -273,14 +273,19 @@ struct FooterView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
-            
+
             Spacer()
-            
+
+            Button("Download All Filings") {
+                viewModel.startDownloadAll()
+            }
+            .disabled(!viewModel.canStartDownloadAll)
+
             Button("Reset") {
                 viewModel.reset()
             }
             .disabled(viewModel.isDownloading)
-            
+
             Button("Download Filings") {
                 viewModel.startDownload()
             }

--- a/SECFilingsDownloader/DownloaderViewModel.swift
+++ b/SECFilingsDownloader/DownloaderViewModel.swift
@@ -86,9 +86,13 @@ class DownloaderViewModel: ObservableObject {
     }
 
     private func performDownload(formTypes: [String]) async {
+        let isDownloadAll = formTypes.isEmpty
+
         isDownloading = true
         downloadProgress = 0
-        statusMessage = "Starting download..."
+        statusMessage = isDownloadAll
+            ? "Starting download for all filings..."
+            : "Starting download..."
         lastDownloadResult = nil
         
         do {
@@ -121,9 +125,13 @@ class DownloaderViewModel: ObservableObject {
             lastDownloadResult = result
             
             if result.total == 0 {
-                statusMessage = "No filings found matching your criteria"
+                statusMessage = isDownloadAll
+                    ? "No filings found for the selected company and dates"
+                    : "No filings found matching your criteria"
             } else {
-                statusMessage = "Successfully downloaded \(result.successful) of \(result.total) filings"
+                statusMessage = isDownloadAll
+                    ? "Successfully downloaded \(result.successful) of \(result.total) available filings"
+                    : "Successfully downloaded \(result.successful) of \(result.total) filings"
             }
             
             // Open the download folder in Finder

--- a/SECFilingsDownloader/DownloaderViewModel.swift
+++ b/SECFilingsDownloader/DownloaderViewModel.swift
@@ -39,9 +39,15 @@ class DownloaderViewModel: ObservableObject {
         downloadFolder != nil &&
         !isDownloading
     }
-    
+
+    var canStartDownloadAll: Bool {
+        !ticker.isEmpty &&
+        downloadFolder != nil &&
+        !isDownloading
+    }
+
     func addFilingType(_ type: FilingType) {
-        if selectedFilingTypes.count < 4 && !selectedFilingTypes.contains(where: { $0.name == type.name }) {
+        if !selectedFilingTypes.contains(where: { $0.name == type.name }) {
             selectedFilingTypes.append(type)
         }
     }
@@ -65,21 +71,27 @@ class DownloaderViewModel: ObservableObject {
     
     func startDownload() {
         guard canStartDownload else { return }
-        
+
         Task {
-            await performDownload()
+            await performDownload(formTypes: selectedFilingTypes.map { $0.name })
         }
     }
-    
-    private func performDownload() async {
+
+    func startDownloadAll() {
+        guard canStartDownloadAll else { return }
+
+        Task {
+            await performDownload(formTypes: [])
+        }
+    }
+
+    private func performDownload(formTypes: [String]) async {
         isDownloading = true
         downloadProgress = 0
         statusMessage = "Starting download..."
         lastDownloadResult = nil
         
         do {
-            let formTypes = selectedFilingTypes.map { $0.name }
-            
             let result = try await apiClient.downloadFilings(
                 tickerOrCIK: ticker.trimmingCharacters(in: .whitespacesAndNewlines),
                 formTypes: formTypes,

--- a/SECFilingsDownloader/SECAPIClient.swift
+++ b/SECFilingsDownloader/SECAPIClient.swift
@@ -101,9 +101,9 @@ class SECAPIClient: ObservableObject {
         for i in 0..<recent.form.count {
             let form = recent.form[i]
             let filingDateStr = recent.filingDate[i]
-            
+
             // Check if form type matches any of the selected types
-            let matchesFormType = formTypes.contains { formType in
+            let matchesFormType = formTypes.isEmpty || formTypes.contains { formType in
                 form.uppercased().contains(formType.uppercased())
             }
             

--- a/SECFilingsDownloader/Views.swift
+++ b/SECFilingsDownloader/Views.swift
@@ -53,11 +53,11 @@ struct FilingTypeSelectorView: View {
                         FilingTypeRow(
                             type: type,
                             isSelected: selectedTypes.contains(where: { $0.name == type.name }),
-                            isDisabled: selectedTypes.count >= 4 && !selectedTypes.contains(where: { $0.name == type.name })
+                            isDisabled: false
                         ) {
                             if selectedTypes.contains(where: { $0.name == type.name }) {
                                 selectedTypes.removeAll { $0.name == type.name }
-                            } else if selectedTypes.count < 4 {
+                            } else {
                                 selectedTypes.append(type)
                             }
                         }
@@ -67,10 +67,10 @@ struct FilingTypeSelectorView: View {
             }
             
             Divider()
-            
+
             // Footer
             HStack {
-                Text("\(selectedTypes.count) of 4 selected")
+                Text("\(selectedTypes.count) selected")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()


### PR DESCRIPTION
## Summary
- remove the four-filing selection cap and simplify the filing type selector UI
- add view model support for unlimited filing type selection and a dedicated download-all action
- allow downloads to fetch every available filing type when requested

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928aa04dc988332829174e061e2e8df)